### PR TITLE
The ants now parse work

### DIFF
--- a/.Hw3Ants.tmp.nlogo
+++ b/.Hw3Ants.tmp.nlogo
@@ -152,8 +152,8 @@ end
 
 to brood-or-forage-worker
   ifelse brood-points = forage-points
-  [ set brood-worker? one-of [true false]]
-  [ set brood-worker? brood-points < forage-points]
+  [ ]
+  [ ]
 
 end
 


### PR DESCRIPTION
The ants now are only allowed to travel in either the forage area or the
nest area.  Paths are erasable, food can be drawn and erased.  The ants
will be assigned to nest if brood points are lower than forage points,
and visa versa